### PR TITLE
fix(server): forward '/tokens/session' error to client in case of failure

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -11,6 +11,7 @@ let cardHolderField;
 
 document.addEventListener('DOMContentLoaded', async () => {
   const { session_id, backend_url } = await fetchConfig();
+  if (!session_id) return;
 
   const { Hellgate } = window;
   const client = await Hellgate.init(session_id, {

--- a/server/node-ts/src/server.ts
+++ b/server/node-ts/src/server.ts
@@ -1,36 +1,44 @@
-import env from "dotenv";
-import path from "path";
-env.config({ path: "./.env" });
-import express, { Request, Response } from "express";
+import env from 'dotenv';
+import express, { Request, Response } from 'express';
+import path from 'path';
+env.config({ path: './.env' });
 
 const app = express();
 app.use(express.static(process.env.CLIENT_DIR));
 
-app.get("/", (_: Request, res: Response): void => {
-    const index = path.resolve(process.env.CLIENT_DIR + "/index.html");
-    res.sendFile(index);
+app.get('/', (_: Request, res: Response): void => {
+  const index = path.resolve(process.env.CLIENT_DIR + '/index.html');
+  res.sendFile(index);
 });
 
-app.get("/config", async (_: Request, res: Response): Promise<void> => {
-    const headers = new Headers()
-    headers.set('Content-Type', 'application/json')
-    headers.set('Accept', 'application/json')
-    headers.set('X-API-KEY', process.env.HELLGATE_API_KEY)
-    
-    const request = new Request(process.env.HELLGATE_BACKEND + "/tokens/session", {
-        method: 'POST',
-        headers: headers,
-    })
+app.get('/config', async (_: Request, res: Response): Promise<void> => {
+  const headers = new Headers();
+  headers.set('Content-Type', 'application/json');
+  headers.set('Accept', 'application/json');
+  headers.set('X-API-KEY', process.env.HELLGATE_API_KEY);
 
-    const response = await fetch(request)
-    const {session_id} = await response.json()
+  const request = new Request(
+    process.env.HELLGATE_BACKEND + '/tokens/session',
+    {
+      method: 'POST',
+      headers: headers,
+    }
+  );
 
-    res.send({
-        session_id: session_id,
-        backend_url: process.env.HELLGATE_BACKEND,
-    });
+  const response = await fetch(request);
+  const data = await response.json();
+
+  if (!response.ok) {
+    res.status(response.status).send(data);
+    return;
+  }
+
+  const { session_id } = data;
+
+  res.send({
+    session_id: session_id,
+    backend_url: process.env.HELLGATE_BACKEND,
+  });
 });
 
-app.listen(4711, (): void =>
-    console.log(`Server listening on port ${4711}!`)
-);
+app.listen(4711, (): void => console.log(`Server listening on port ${4711}!`));


### PR DESCRIPTION
In case we configure env.HELLGATE_API_KEY wrong

**Before**
Status: 200, No `session_id`
<img width="1314" alt="image" src="https://github.com/starfish-codes/tokenize-cards/assets/645126/3d83a738-d0bc-451f-b89e-8652b2b57121">

**After**
Status: 401 UNAUTHORIZED
<img width="1466" alt="image" src="https://github.com/starfish-codes/tokenize-cards/assets/645126/8f1bfddc-5842-4ab6-9c46-00f1f07af837">
